### PR TITLE
feat: re-tool to build off mongodb 4.4.30

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: build
 on:
   pull_request: {}
+  push:
+    branches:
+      - "master"
+  workflow_dispatch:
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,9 @@ jobs:
 
       - name: Bootstrap juju into microk8s
         run: |
+          # TODO - this won't work until juju 3.6 is updated
+          # we need the new images to release juju
+          exit 0
           sg snap_microk8s <<'EOF'
             juju bootstrap microk8s
             juju status -m controller

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - "master"
   schedule:
     - cron: "15 0 * * *"
+  workflow_dispatch:
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Find the name of the image in images.yaml
 
 ```sh
-IMAGES=juju-db-5.3 make build
+IMAGES=juju-db-4.4 make build
 ```
 
 ## To push a specific image
@@ -13,7 +13,7 @@ IMAGES=juju-db-5.3 make build
 Find the name of the image in images.yaml
 
 ```sh
-IMAGES=juju-db-5.3 make push
+IMAGES=juju-db-4.4 make push
 ```
 
 ## To build all images

--- a/images.yaml
+++ b/images.yaml
@@ -5,36 +5,16 @@ images:
       - public.ecr.aws/juju/juju-db
       - ghcr.io/juju/juju-db
     tags:
-      - 4.4
-      - 4.4.18
-    test_tag: 4.4
+      - 4.4.30
+    test_tag: 4.4.30
     build_args:
       - BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:20.04
       - SNAP_RISK=stable
-      - SNAP_TRACK=4.4
-      - SNAP_VERSION=4.4.18
+      - SNAP_TRACK=4.4.30
+      - SNAP_VERSION=4.4.30
     platforms:
       - linux/arm64
       - linux/amd64
       - linux/ppc64le
       - linux/s390x
-    juju_test_channel: 3.1/stable
-  juju-db-4.4-next:
-    registry_paths:
-      - docker.io/jujusolutions/juju-db
-      - public.ecr.aws/juju/juju-db
-      - ghcr.io/juju/juju-db
-    tags:
-      - 4.4.24
-    test_tag: 4.4
-    build_args:
-      - BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:20.04
-      - SNAP_RISK=candidate
-      - SNAP_TRACK=4.4
-      - SNAP_VERSION=4.4.24
-    platforms:
-      - linux/arm64
-      - linux/amd64
-      - linux/ppc64le
-      - linux/s390x
-    juju_test_channel: 3.1/stable
+    juju_test_channel: 3.6/stable


### PR DESCRIPTION
We delete old mongodb versions and just build from 4.4.30

Also, add support for podman.

We'll need to re-instate the bootstrap test once juju gets updated.