### PR TITLE
fix: add set up steps needed to do make push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,6 +105,28 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make
+          wget https://github.com/mikefarah/yq/releases/download/v4.20.1/yq_linux_amd64 -O yq
+          chmod +x yq
+          sudo chown root:root yq
+          sudo mv yq /usr/bin/yq
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
When the separate release workflow was added, we also need to include the steps to set up docker and checkout the source code.